### PR TITLE
Store all classes types at the instantiation of the context

### DIFF
--- a/frontend/context.py
+++ b/frontend/context.py
@@ -9,6 +9,13 @@ class Context:
     """
 
     def __init__(self, context_nodes, solver, name="", parent_context=None):
+        """
+        
+        :param context_nodes: The AST nodes that belong to this scope. Used to pre-store all class types in the scope. 
+        :param solver: The SMT solver for the inference. Used to create new Z3 constants for the class types.
+        :param name: The context name
+        :param parent_context: Reference to the parent scope (context)
+        """
         self.name = name
         self.types_map = {}
 

--- a/frontend/context.py
+++ b/frontend/context.py
@@ -1,3 +1,6 @@
+import ast
+
+
 class Context:
     """Represents types scope in a python program.
 
@@ -5,9 +8,18 @@ class Context:
         types_map ({str, Type}): a dict mapping variable names to their inferred types.
     """
 
-    def __init__(self, name="", parent_context=None):
+    def __init__(self, context_nodes, solver, name="", parent_context=None):
         self.name = name
         self.types_map = {}
+
+        # Store all the class types that appear in this context. This enables using
+        # classes in no specific order.
+        class_names = [node.name for node in context_nodes if isinstance(node, ast.ClassDef)]
+        for cls in class_names:
+            cls_type = solver.new_z3_const("class_type")
+            self.types_map[cls] = cls_type
+            solver.z3_types.all_types[cls] = cls_type
+
         self.builtin_methods = {}
         self.parent_context = parent_context
         self.children_contexts = []

--- a/frontend/expr_inferrer.py
+++ b/frontend/expr_inferrer.py
@@ -341,7 +341,7 @@ def infer_sequence_comprehension(node, sequence_type, context, solver):
         The iterable should always be a list or a set (not a tuple or a dict)
         The iteration target should be always a variable name.
     """
-    local_context = Context(parent_context=context)
+    local_context = Context([], solver, parent_context=context)
     infer_generators(node.generators, local_context, node.lineno, solver)
     return sequence_type(infer(node.elt, local_context, solver))
 
@@ -361,7 +361,7 @@ def infer_dict_comprehension(node, context, solver):
         The iterable should always be a list or a set (not a tuple or a dict)
         The iteration target should be always a variable name.
     """
-    local_context = Context(parent_context=context)
+    local_context = Context([], solver, parent_context=context)
     infer_generators(node.generators, local_context, node.lineno, solver)
     key_type = infer(node.key, local_context, solver)
     val_type = infer(node.value, local_context, solver)

--- a/frontend/import_handler.py
+++ b/frontend/import_handler.py
@@ -39,13 +39,12 @@ class ImportHandler:
     @staticmethod
     def infer_import(module_name, base_folder, infer_func, solver):
         """Infer the types of a python module"""
-        context = Context()
-
         if ImportHandler.is_builtin(module_name):
-            solver.stubs_handler.infer_builtin_lib(module_name, context, solver,
-                                                   solver.config.used_names, infer_func)
+            return solver.stubs_handler.infer_builtin_lib(module_name, solver,
+                                                          solver.config.used_names, infer_func)
         else:
             t = ImportHandler.get_module_ast(module_name, base_folder)
+            context = Context(t.body, solver)
             solver.infer_stubs(context, infer_func)
             for stmt in t.body:
                 infer_func(stmt, context, solver)

--- a/frontend/stmt_inferrer.py
+++ b/frontend/stmt_inferrer.py
@@ -190,8 +190,8 @@ def _infer_control_flow(node, context, solver):
 
         type: super{String, Float}
     """
-    body_context = Context(parent_context=context)
-    else_context = Context(parent_context=context)
+    body_context = Context(node.body, solver, parent_context=context)
+    else_context = Context(node.body, solver, parent_context=context)
 
     body_type = _infer_body(node.body, body_context, node.lineno, solver)
     else_type = _infer_body(node.orelse, else_context, node.lineno, solver)
@@ -301,9 +301,9 @@ def _infer_try(node, context, solver):
     return result_type
 
 
-def _init_func_context(name, args, context, solver):
+def _init_func_context(node, args, context, solver):
     """Initialize the local function scope, and the arguments types"""
-    local_context = Context(name=name, parent_context=context)
+    local_context = Context(node.body, solver, name=node.name, parent_context=context)
 
     # TODO starred args
 
@@ -413,9 +413,9 @@ def _infer_func_def(node, context, solver):
                                                                                      defaults_count)
         else:
             context.set_type(node.name, AnnotatedFunction(args_annotations, return_annotation, defaults_count))
-        return
+        return solver.z3_types.none
 
-    func_context, args_types = _init_func_context(node.name, node.args.args, context, solver)
+    func_context, args_types = _init_func_context(node, node.args.args, context, solver)
     result_type = solver.new_z3_const("func")
     result_type.args_count = len(node.args.args)
     context.set_type(node.name, result_type)
@@ -441,12 +441,12 @@ def _infer_func_def(node, context, solver):
     func_type = solver.z3_types.funcs[len(args_types)]((defaults_len,) + args_types + (body_type,))
     solver.add(result_type == func_type,
                fail_message="Function definition in line {}".format(node.lineno))
+    return solver.z3_types.none
 
 
 def _infer_class_def(node, context, solver):
-    class_context = Context(name=node.name, parent_context=context)
-    result_type = solver.new_z3_const("class_type")
-    solver.z3_types.all_types[node.name] = result_type
+    class_context = Context(node.body, solver, name=node.name, parent_context=context)
+    result_type = context.get_type(node.name)
 
     for stmt in node.body:
         infer(stmt, class_context, solver)
@@ -469,7 +469,7 @@ def _infer_class_def(node, context, solver):
     class_type = solver.z3_types.type(instance_type)
     solver.add(result_type == class_type, fail_message="Class definition in line {}".format(node.lineno))
     result_type.is_class = True
-    context.set_type(node.name, result_type)
+    return solver.z3_types.none
 
 
 def _infer_import(node, context, solver):

--- a/frontend/z3_types.py
+++ b/frontend/z3_types.py
@@ -41,7 +41,7 @@ class TypesSolver(Solver):
         self.assertions_vars = []
         self.assertions_errors = {}
         self.stubs_handler = StubsHandler()
-        analyzer = PreAnalyzer(tree, "tests/inference", self.stubs_handler)     # TODO: avoid hard-coding
+        analyzer = PreAnalyzer(tree, "tests", self.stubs_handler)     # TODO: avoid hard-coding
         self.config = analyzer.get_all_configurations()
         self.z3_types = Z3Types(self.config)
         self.annotation_resolver = AnnotationResolver(self.z3_types)

--- a/tests/inference_runner.py
+++ b/tests/inference_runner.py
@@ -8,7 +8,7 @@ r.close()
 
 solver = z3_types.TypesSolver(t)
 
-context = Context()
+context = Context(t.body, solver)
 solver.infer_stubs(context, infer)
 
 for stmt in t.body:

--- a/unittests/inference/class_pre_store.py
+++ b/unittests/inference/class_pre_store.py
@@ -1,0 +1,20 @@
+class A:
+    def f(self):
+        return B()
+
+    def g(self):
+        return self.f().g()
+
+
+class B(A):
+    def g(self):
+        return "string"
+
+
+x = A()
+y = x.g()
+
+# A := Type[A]
+# B := Type[B]
+# x := A
+# y := str

--- a/unittests/inference_tests.py
+++ b/unittests/inference_tests.py
@@ -54,7 +54,7 @@ class TestInference(unittest.TestCase):
 
         solver = z3_types.TypesSolver(t)
 
-        context = Context()
+        context = Context(t.body, solver)
 
         solver.infer_stubs(context, infer)
 
@@ -85,7 +85,7 @@ class TestInference(unittest.TestCase):
 
         check = solver.optimize.check()
         if self.sat:
-            self.assertNotEqual(check, z3_types.unsat)
+            self.assertNotEqual(check, z3_types.unsat, self.file_name)
         else:
             self.assertEqual(check, z3_types.unsat)
             end_time = time.time()


### PR DESCRIPTION
- The context takes an extra argument for the the node for which this context is created.
- at `__init__` of the context, the class types existing in this context is added to the types map.

Fixes #4 