### PR TITLE
Added support for staticmethod inference

### DIFF
--- a/frontend/expr_inferrer.py
+++ b/frontend/expr_inferrer.py
@@ -434,6 +434,11 @@ def infer_func_call(node, context, solver):
         # Add axioms for built-in methods
         call_axioms += _get_builtin_method_call_axioms(args_types, solver, context, result_type, node.func.attr)
 
+        if instance is not None:
+            # Add disjunctions for staticmethod calls
+            # Remove the first arg (which is the method receiver) from the call args types.
+            call_axioms += axioms.staticmethod_call(instance, args_types[1:], result_type,
+                                                    node.func.attr, solver.z3_types)
     called = infer(node.func, context, solver)
     if isinstance(called, AnnotatedFunction):
         func_axioms = solver.annotation_resolver.get_annotated_function_axioms(args_types, solver, called, result_type)

--- a/frontend/z3_axioms.py
+++ b/frontend/z3_axioms.py
@@ -427,6 +427,23 @@ def call(called, args, result, types):
     ]
 
 
+def staticmethod_call(class_type, args, result, attr, types):
+    """Constraints for staticmethod calls
+    
+    Assert with all classes which has the method `attr` which has decorator `staticmethod`
+    """
+    axioms = []
+    for t in types.all_types:
+        # Check that attr is a method and "staticmethod" is one of its decorators
+        if attr in types.class_to_funcs[t]:
+            decorators = types.class_to_funcs[t][attr][1]
+            if "staticmethod" in decorators:
+                attr_type = types.instance_attributes[t][attr]
+                axioms.append(And(class_type == types.all_types[t],
+                                  Or(function_call_axioms(attr_type, args, result, types))))
+    return axioms
+
+
 def attribute(instance, attr, result, types):
     """Constraints for attribute access
     
@@ -444,5 +461,4 @@ def attribute(instance, attr, result, types):
             class_type = types.all_types[t]
             attr_type = types.class_attributes[t][attr]
             axioms.append(And(instance == class_type, result == attr_type))
-
     return Or(axioms)

--- a/unittests/inference/staticmethod.py
+++ b/unittests/inference/staticmethod.py
@@ -1,0 +1,17 @@
+class A:
+    @staticmethod
+    def f():
+        return 1
+
+    def g(self):
+        return A.f()
+
+x = A.f()
+y = A().g()
+
+# A := Type[A]
+# f := Callable[[], int]
+# g := Callable[[A], int]
+
+# x := int
+# y := int


### PR DESCRIPTION
When we have a call where the called is an attribute access, disjunctions for possible static methods are added.

Fixes #12 