### PR TITLE
Allow circular imports

### DIFF
--- a/frontend/import_handler.py
+++ b/frontend/import_handler.py
@@ -55,10 +55,10 @@ class ImportHandler:
         else:
             t = ImportHandler.get_module_ast(module_name, base_folder)
             context = Context(t.body, solver)
+            ImportHandler.cached_modules[module_name] = context
             solver.infer_stubs(context, infer_func)
             for stmt in t.body:
                 infer_func(stmt, context, solver)
-            ImportHandler.cached_modules[module_name] = context
         return ImportHandler.cached_modules[module_name]
 
     @staticmethod

--- a/frontend/pre_analysis.py
+++ b/frontend/pre_analysis.py
@@ -22,6 +22,7 @@ class PreAnalyzer:
         """
         # List all the nodes existing in the AST
         self.base_folder = base_folder
+        self.analyzed = set()
         self.all_nodes = self.walk(prog_ast)
 
         # Pre-analyze only used constructs from the stub files.
@@ -37,10 +38,13 @@ class PreAnalyzer:
         import_from_nodes = [node for node in result if isinstance(node, ast.ImportFrom)]
         for node in import_nodes:
             for name in node.names:
+                if name in self.analyzed:
+                    continue
                 if ImportHandler.is_builtin(name.name):
                     new_ast = ImportHandler.get_builtin_ast(name.name)
                 else:
                     new_ast = ImportHandler.get_module_ast(name.name, self.base_folder)
+                self.analyzed.add(name)
                 result += self.walk(new_ast)
         for node in import_from_nodes:
             if node.module == "typing":

--- a/frontend/z3_types.py
+++ b/frontend/z3_types.py
@@ -42,7 +42,7 @@ class TypesSolver(Solver):
         self.assertions_vars = []
         self.assertions_errors = {}
         self.stubs_handler = StubsHandler()
-        analyzer = PreAnalyzer(tree, "tests/imp", self.stubs_handler)     # TODO: avoid hard-coding
+        analyzer = PreAnalyzer(tree, "tests", self.stubs_handler)     # TODO: avoid hard-coding
         self.config = analyzer.get_all_configurations()
         self.z3_types = Z3Types(self.config)
         self.annotation_resolver = AnnotationResolver(self.z3_types)

--- a/tests/inference_runner.py
+++ b/tests/inference_runner.py
@@ -3,7 +3,7 @@ import ast
 import time
 import astunparse
 
-file_path = "tests/imp/imp.py"
+file_path = "tests/test.py"
 file_name = file_path.split("/")[-1]
 
 r = open(file_path)


### PR DESCRIPTION
Added support for circular imports.

### Changes:
- Run the pre-analysis on an imported no more than once.
- Cache the imported context before running the inference algorithm on it, so the next time it is encountered, the cached one will be returned.

### Behavior:
Works like it does in Python. When a circular import occurs, only parts of the module that appear before the import statements are considered. For example the following will raise an error:

A.py
```python
import B

def f():...
```

B.py
```python
import A

A.f()

# Error: A has no attribute f
```

However, the following is supported:

A.py
```python
def f():...

import B
```

B.py
```python
import A

A.f()
```



