### PR TITLE
Surround forward-referncing annotations with string literals

### DIFF
--- a/typpete/src/annotation_resolver.py
+++ b/typpete/src/annotation_resolver.py
@@ -246,12 +246,17 @@ class AnnotationResolver:
                        fail_message="Upper bound of type variable {}".format(
                            type_var_name))
 
-    def unparse_annotation(self, z3_type):
+    def unparse_annotation(self, z3_type, context_name=None, lineno=0, definition_linenos=None):
         """Unparse the z3_type into a type annotation in PEP 484 syntax
-        
+
         :param z3_type: The z3 type to be unparsed
+        :param context_name: The name of the context this annotation occurs in
+        :param lineno: The line number this annotation is added to
+        :param definition_linenos: The line numbers for type definitions. Used for detecting forward referencing
         :returns str: the unparsed z3_type in PEP 484 syntax
         """
+        if not definition_linenos:
+            definition_linenos = {}
         type_str = str(z3_type)
 
         if type_str in self.z3_type_to_PEP: # check if normal type
@@ -265,7 +270,7 @@ class AnnotationResolver:
             # get the list elements' type
             list_type_accessor = self.z3_types.list_type
             list_type = simplify(list_type_accessor(z3_type))
-            return "List[{}]".format(self.unparse_annotation(list_type))
+            return "List[{}]".format(self.unparse_annotation(list_type, context_name, lineno, definition_linenos))
 
         match = re.match("class_(.+)", type_str)
         # unparse user defined class types. Example: class_A -> A
@@ -286,7 +291,11 @@ class AnnotationResolver:
                     instance = simplify(accessor(z3_type))
                     args.append(self.unparse_annotation(instance))
                 return '{}[{}]'.format(generic_name, ', '.join(args))
-            return match.group(1)
+            annotation = match.group(1)
+            if annotation in definition_linenos and (lineno <= definition_linenos[annotation]
+                                                     or context_name == annotation):
+                annotation = "'" + annotation + "'"
+            return annotation
 
         match = re.match("type", type_str)
         # unparse type type. Example: type_type(class_A) -> Type[A]
@@ -294,7 +303,7 @@ class AnnotationResolver:
             # get the instance of this type
             instance_accessor = getattr(self.z3_types.type_sort, "type_arg_0")
             instance = simplify(instance_accessor(z3_type))
-            return "Type[{}]".format(self.unparse_annotation(instance))
+            return "Type[{}]".format(self.unparse_annotation(instance, context_name, lineno, definition_linenos))
 
         if type_str == "tuple_0":
             # unparse zero-length tuple. tuple_0 -> Tuple[()]
@@ -309,7 +318,7 @@ class AnnotationResolver:
                 # Get the accessor for every tuple arg.
                 arg_accessor = getattr(self.z3_types.type_sort, "tuple_{}_arg_{}".format(tuple_len, i + 1))
                 arg = simplify(arg_accessor(z3_type))
-                args.append(self.unparse_annotation(arg))
+                args.append(self.unparse_annotation(arg, context_name, lineno, definition_linenos))
 
             args_str = ", ".join(args)
             return "Tuple[{}]".format(args_str)
@@ -319,7 +328,7 @@ class AnnotationResolver:
         if match:
             set_type_accessor = self.z3_types.set_type
             set_type = simplify(set_type_accessor(z3_type))
-            return "Set[{}]".format(self.unparse_annotation(set_type))
+            return "Set[{}]".format(self.unparse_annotation(set_type, context_name, lineno, definition_linenos))
 
         match = re.match("dict", type_str)
         # unparse dict type. dict(int, str) -> Dict[int, str]
@@ -329,8 +338,8 @@ class AnnotationResolver:
             key_type = simplify(key_accessor(z3_type))
             val_type = simplify(val_accessor(z3_type))
 
-            return "Dict[{}, {}]".format(self.unparse_annotation(key_type),
-                                         self.unparse_annotation(val_type))
+            return "Dict[{}, {}]".format(self.unparse_annotation(key_type, context_name, lineno, definition_linenos),
+                                         self.unparse_annotation(val_type, context_name, lineno, definition_linenos))
 
         match = re.match("func_(\d+)", type_str)
         # unparse func type. func_0(0, int, none) -> Callable[[int], None]
@@ -340,10 +349,10 @@ class AnnotationResolver:
             for i in range(args_len):
                 arg_accessor = getattr(self.z3_types.type_sort, "func_{}_arg_{}".format(args_len, i + 1))
                 arg = simplify(arg_accessor(z3_type))
-                args.append(self.unparse_annotation(arg))
+                args.append(self.unparse_annotation(arg, context_name, lineno, definition_linenos))
             return_accessor = getattr(self.z3_types.type_sort, "func_{}_return".format(args_len))
             return_type = simplify(return_accessor(z3_type))
-            return_annotation = self.unparse_annotation(return_type)
+            return_annotation = self.unparse_annotation(return_type, context_name, lineno, definition_linenos)
 
             return "Callable[[{}], {}]".format(", ".join(args), return_annotation)
 

--- a/typpete/src/context.py
+++ b/typpete/src/context.py
@@ -28,9 +28,14 @@ class Context:
         self.is_func = is_func
         self.types_map = {}
         self.isinstance_nodes = {}
+        self.definition_linenos = {}
+        if parent_context:
+            # Propagate the types lineno recordings
+            self.definition_linenos.update(parent_context.definition_linenos)
         self.node = node
         self.context_nodes = context_nodes
 
+        self.add_definition_linenos()
         self.add_nodes(context_nodes, solver)
 
         self.builtin_methods = {}
@@ -44,6 +49,21 @@ class Context:
 
         if parent_context:
             parent_context.children_contexts.append(self)
+
+    def add_definition_linenos(self):
+        """
+        Add the lineno of every type in the context
+        It is either imported from another module or defined in this context as a class definition
+        """
+        for node in self.context_nodes:
+            if isinstance(node, ast.Import):
+                for name in node.names:
+                    if name.asname:
+                        self.definition_linenos[name.asname] = node.lineno
+                    else:
+                        self.definition_linenos[name.name] = node.lineno
+            elif isinstance(node, ast.ClassDef):
+                self.definition_linenos[node.name] = node.lineno
 
     def add_nodes(self, context_nodes, solver):
         # Store all the class types that appear in this context. This enables using
@@ -72,14 +92,12 @@ class Context:
             raise NameError("Name {} is not defined.".format(var_name))
         return self.parent_context.get_type(var_name, passed_func)
 
-
     def get_isinstance_type(self, dump):
         if dump in self.isinstance_nodes:
             return self.isinstance_nodes[dump]
         if self.parent_context is None:
             raise NameError("Cannot find isinstance node")
         return self.parent_context.get_isinstance_type(dump)
-
 
     def set_type(self, var_name, var_type):
         """Sets the type of a variable in this context."""
@@ -221,13 +239,13 @@ class Context:
                 arg_accessor_func = lambda i, n: getattr(type_sort, "func_{}_arg_{}".format(n, i))
                 return_accessor_func = lambda n: getattr(type_sort, "func_{}_return".format(n))
 
-
             # Add the type annotations for the function arguments
             for i, arg in enumerate(node.args.args):
                 arg_type = simplify(arg_accessor_func(i + 1, func_len)(inferred_type))
 
                 # Get the annotation with PEP 484 syntax
-                arg_annotation_str = solver.annotation_resolver.unparse_annotation(arg_type)
+                arg_annotation_str = solver.annotation_resolver.unparse_annotation(arg_type, self.name,
+                                                                                   node.lineno, self.definition_linenos)
                 # Add the type annotation as an AST node
                 arg.annotation = ast.parse(arg_annotation_str).body[0].value
 
@@ -236,7 +254,8 @@ class Context:
 
             # Similarly, add the return type annotation
             return_type = simplify(return_accessor_func(func_len)(inferred_type))
-            return_annotation_str = solver.annotation_resolver.unparse_annotation(return_type)
+            return_annotation_str = solver.annotation_resolver.unparse_annotation(return_type, self.name,
+                                                                                  node.lineno, self.definition_linenos)
             node.returns = ast.parse(return_annotation_str).body[0].value
 
             names = {name.id for name in list(ast.walk(node.returns)) if isinstance(name, ast.Name)}
@@ -267,7 +286,7 @@ class Context:
                 if isinstance(node.targets[0], ast.Tuple):
                     try:
                         # Unfold tuple assignment
-                        assigns = get_unfolded_assignments(node.targets[0], node.value, z3_t, model, solver)
+                        assigns = self.get_unfolded_assignments(node.targets[0], node.value, z3_t, model, solver, self.definition_linenos)
                         if not assigns or node not in self.context_nodes:
                             continue
                         idx = self.context_nodes.index(node)
@@ -284,7 +303,8 @@ class Context:
                 node.__class__ = ast.AnnAssign
                 node.target = node.targets[0]
                 node.simple = 1
-                annotation_str = solver.annotation_resolver.unparse_annotation(z3_t)
+                annotation_str = solver.annotation_resolver.unparse_annotation(z3_t, self.name,
+                                                                               node.lineno,self.definition_linenos)
                 node.annotation = ast.parse(annotation_str).body[0].value
 
                 names = {name.id for name in list(ast.walk(node.annotation)) if isinstance(name, ast.Name)}
@@ -329,38 +349,39 @@ class Context:
         raise NameError("Context {} is not defined".format(context_name))
 
 
-def get_unfolded_assignments(node, value, z3_t, model, solver):
-    if isinstance(node, ast.Tuple):
-        if not isinstance(value, ast.Tuple):
+    def get_unfolded_assignments(self, node, value, z3_t, model, solver, definition_linenos):
+        if isinstance(node, ast.Tuple):
+            if not isinstance(value, ast.Tuple):
+                return [ast.Assign(
+                    targets=[node],
+                    value=value
+                )]
+            tuple_len = len(node.elts)
+            nodes = []
+            for i in range(tuple_len):
+                arg_accessor = getattr(solver.z3_types.type_sort, "tuple_{}_arg_{}".format(tuple_len, i + 1))
+                arg_z3_t = arg_accessor(z3_t)
+                cur = self.get_unfolded_assignments(node.elts[i], value.elts[i], arg_z3_t, model, solver, definition_linenos)
+                nodes += cur
+            return nodes
+        elif isinstance(node, (ast.Name, ast.Attribute)):
+            z3_t = simplify(z3_t)
+            z3_t = model[z3_t] if model[z3_t] is not None else z3_t
+            annotation_str = solver.annotation_resolver.unparse_annotation(z3_t, self.name,
+                                                                           node.lineno, self.definition_linenos)
+            annotation = ast.parse(annotation_str).body[0].value
+            node = ast.AnnAssign(
+                target=node,
+                value=value,
+                annotation=annotation,
+                simple=1
+            )
+            return [node]
+        else:
             return [ast.Assign(
                 targets=[node],
                 value=value
             )]
-        tuple_len = len(node.elts)
-        nodes = []
-        for i in range(tuple_len):
-            arg_accessor = getattr(solver.z3_types.type_sort, "tuple_{}_arg_{}".format(tuple_len, i + 1))
-            arg_z3_t = arg_accessor(z3_t)
-            cur = get_unfolded_assignments(node.elts[i], value.elts[i], arg_z3_t, model, solver)
-            nodes += cur
-        return nodes
-    elif isinstance(node, (ast.Name, ast.Attribute)):
-        z3_t = simplify(z3_t)
-        z3_t = model[z3_t] if model[z3_t] is not None else z3_t
-        annotation_str = solver.annotation_resolver.unparse_annotation(z3_t)
-        annotation = ast.parse(annotation_str).body[0].value
-        node = ast.AnnAssign(
-            target=node,
-            value=value,
-            annotation=annotation,
-            simple=1
-        )
-        return [node]
-    else:
-        return [ast.Assign(
-            targets=[node],
-            value=value
-        )]
 
 
 


### PR DESCRIPTION
- Keep track of the line no of every type definition/import
- In the generation of the annotation, check if either of the following is true, if so, then it is forward referencing 
    - The line number of the type definition follows the line no of the annotation
    - The name of the context is the name is the same as the name of the type